### PR TITLE
[Finishes #163550574] sw caches html, css and js files for perf concerns

### DIFF
--- a/UI/Js/render.js
+++ b/UI/Js/render.js
@@ -38,3 +38,17 @@ const layout = {
     }
   ]
 };
+
+if ("serviceWorker" in navigator) {
+  console.log("CLIENT: service worker registration in progress.");
+  navigator.serviceWorker.register("./Js/service-worker.js").then(
+    function() {
+      console.log("CLIENT: service worker registration complete.");
+    },
+    function(e) {
+      console.log("CLIENT: service worker registration failure.", e);
+    }
+  );
+} else {
+  console.log("CLIENT: service worker is not supported.");
+}

--- a/UI/Js/service-worker.js
+++ b/UI/Js/service-worker.js
@@ -1,0 +1,114 @@
+"use strict";
+
+console.log("SERVICE WORKER IS LIVE.");
+
+var version = "Politico1::";
+
+var offlineResources = [
+  "../admindash.html",
+  "../index.html",
+  "../login.html",
+  "../politician.html",
+  "../sign-up.html",
+  "./render.js",
+  "./validation.js",
+  "../main.css"
+];
+
+self.addEventListener("install", function(event) {
+  console.log("WORKER: install event in progress.");
+
+  event.waitUntil(
+    caches
+      .open(version + "fundamentals")
+      .then(function(cache) {
+        return cache.addAll(offlineResources);
+      })
+      .then(function() {
+        console.log("SERVICE WORKER: install completed");
+      })
+  );
+});
+
+self.addEventListener("fetch", function(event) {
+  console.log("WORKER: fetch event in progress.");
+
+  if (event.request.method !== "GET") {
+    console.log(
+      "WORKER: fetch event ignored.",
+      event.request.method,
+      event.request.url
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(function(cached) {
+      var networked = fetch(event.request)
+        .then(fetchedFromNetwork, unableToResolve)
+        .catch(unableToResolve);
+
+      console.log(
+        "WORKER: fetch event",
+        cached ? "(cached)" : "(network)",
+        event.request.url
+      );
+      return cached || networked;
+
+      function fetchedFromNetwork(response) {
+        var cacheCopy = response.clone();
+
+        console.log("WORKER: fetch response from network.", event.request.url);
+
+        caches
+          .open(version + "pages")
+          .then(function add(cache) {
+            return cache.put(event.request, cacheCopy);
+          })
+          .then(function() {
+            console.log(
+              "WORKER: fetch response stored in cache.",
+              event.request.url
+            );
+          });
+
+        return response;
+      }
+
+      function unableToResolve() {
+        console.log("WORKER: fetch request failed in both cache and network.");
+
+        return new Response("<h1>Service Unavailable</h1>", {
+          status: 503,
+          statusText: "Service Unavailable",
+          headers: new Headers({
+            "Content-Type": "text/html"
+          })
+        });
+      }
+    })
+  );
+});
+
+self.addEventListener("activate", function(event) {
+  console.log("WORKER: activate event in progress.");
+
+  event.waitUntil(
+    caches
+      .keys()
+      .then(function(keys) {
+        return Promise.all(
+          keys
+            .filter(function(key) {
+              return !key.startsWith(version);
+            })
+            .map(function(key) {
+              return caches.delete(key);
+            })
+        );
+      })
+      .then(function() {
+        console.log("WORKER: activate completed.");
+      })
+  );
+});

--- a/UI/Js/validation.js
+++ b/UI/Js/validation.js
@@ -10,3 +10,4 @@ function areValuesEqual(val1, val2) {
 function doesFieldContainValidValue(value) {
   return /\S/.test(value) && Boolean(value);
 }
+


### PR DESCRIPTION
**What does this PR Do?**
This PR merges a service-worker so that it can cache the static assets available so that subsequent visits to the web app will not fetch resources from the cloud hosting service but from the browser's cache.

**Describe the task to be completed?**
Making the web app faster by using a service worker so that subsequent visits to the site fetch resources from the browser's cache.

**How do I manually test this**
1. Clone the repo
2. Download VS-Code
3. Download `Live-server` extension
4. Click on `go live` at the bottom of vs code
![image](https://user-images.githubusercontent.com/12128153/52010827-83df3700-24e7-11e9-8bb2-be80ecbccc8b.png)

5. Open up any HTML file via the port `Live-server` starts via chrome

6. Reload page and go to application panel in dev tools

7. Click on `cache-storage` and you will see the files cached in the browser


**PT stories relevant to this PR?**
https://www.pivotaltracker.com/n/projects/2241721/stories/163550574

![image](https://user-images.githubusercontent.com/12128153/52011001-efc19f80-24e7-11e9-92d3-845ef299dac8.png)


