### PR TITLE
[Finishes #163548925] Set up gvt-office-creation page

### DIFF
--- a/UI/newgvtposition.html
+++ b/UI/newgvtposition.html
@@ -16,7 +16,7 @@
             type="text"
             name="name"
             id="name"
-            placeholder="Party Name"
+            placeholder="Office Name"
           /><br /><br />
 
           <div id="submit-button">
@@ -24,14 +24,14 @@
               type="submit"
               id="submit"
               disabled="true"
-              value="Create Party"
+              value="Create Office"
             />
           </div>
         </form>
         <div style="height: 30px"></div>
-        <h4 class="how_it_works">List of political Parties Present</h4>
+        <h4 class="how_it_works">List of government offices</h4>
         <div style="height: 30px"></div>
-        <div id="list-of-parties"></div>
+        <div id="list-of-offices"></div>
       </div>
     </div>
 
@@ -40,24 +40,19 @@
     <script>
       let partyname;
       let submitbtn = document.getElementById("submit");
-      let partylistcontainer = document.getElementById("list-of-parties");
-      let partylist = document.getElementById("partylist");
+      let positionscontainer = document.getElementById("list-of-offices");
+      let positionslist = document.getElementById("positionslist");
 
       function getValue(event) {
         return event.target.value;
       }
 
-      let parties = [
-        "House Stark",
-        "House Baratheon",
-        "House GreyJoy",
-        "House Lannister"
-      ];
+      let offices = ["Secretary General", "Gvt Spokesman", "Treasurer"];
 
       const renderingList = {
         type: "ul",
-        props: { id: "partylist" },
-        children: parties.map(party => ({
+        props: { id: "positionslist" },
+        children: offices.map(party => ({
           type: "li",
           props: {},
           children: [party]
@@ -66,8 +61,8 @@
 
       function shouldSubmitBeActive() {
         if (doesFieldContainValidValue(partyname)) {
-          if (parties.includes(partyname)) {
-            submitbtn.setAttribute("value", "Party name already exists");
+          if (offices.includes(partyname)) {
+            submitbtn.setAttribute("value", "Government Post already exists");
             submitbtn.setAttribute("disabled", true);
           } else {
             submitbtn.removeAttribute("disabled");
@@ -83,20 +78,20 @@
       // submit name
       document.getElementById("sigin-in-form").onsubmit = function(event) {
         event.preventDefault();
-        parties = [...parties, partyname];
+        offices = [...offices, partyname];
         const p = {
           type: "li",
           props: {},
           children: [partyname]
         };
-        document.getElementById("partylist").appendChild(createElement(p));
+        document.getElementById("positionslist").appendChild(createElement(p));
         document.getElementById("name").value = "";
         submitbtn.setAttribute("disabled", true);
-        submitbtn.setAttribute("value", "Create Party");
+        submitbtn.setAttribute("value", "CREATE OFFICE");
       };
 
-      // RENDER THE LIST OF PARTIES PRESENT
-      partylistcontainer.appendChild(createElement(renderingList));
+      // RENDER THE LIST OF offices PRESENT
+      positionscontainer.appendChild(createElement(renderingList));
 
       const $header = document.getElementById("heading-container");
       $header.appendChild(createElement(layout));


### PR DESCRIPTION
**What does this PR do?**
This PR adds the office creation page to the so that an admin can create posts/offices that were non-existent. There's also a JavaScript helper function that helps make sure duplicate positions are not submitted.

**Describe the task to be accomplished?**
Add a government position creation page where the admin will be responsible for adding positions.

**How should this be manually tested?**

1. Clone this repo
2. Open `newgvtposition.html` in the UI directory
3. Try entering a name that is already in the list of positions eg: `Secretary General` and you will see the submit button change its value from `Create Office` to `Government post already exists`
4. Enter any other government name you can think of that is not in the list and you will instantly see the submit button becomes enabled, upon hitting submit, your new post is then recorded to the list of offices.

**PT stories relevant to this PR?**
[#163548925](https://andela-workshops.slack.com/messages/CFRS5HBE3/convo/CFRS5HBE3-1548918283.019300)

**Screenshots?**

![image](https://user-images.githubusercontent.com/12128153/52053744-46bc8880-256b-11e9-9015-f0b02fccbccd.png)


![image](https://user-images.githubusercontent.com/12128153/52053783-5936c200-256b-11e9-8abd-27707ac6841d.png)
