### PR TITLE
#164349046 Add isAdmin prop on list of users

### DIFF
--- a/app/api/v2/models/users.py
+++ b/app/api/v2/models/users.py
@@ -79,7 +79,8 @@ class UserModel:
             d = {
                 "id": item[0],
                 "username": item[1],
-                "email": item[2]
+                "email": item[2],
+                "isAdmin": item[3]
             }
             results.append(d)
         return results
@@ -100,7 +101,7 @@ class UserModel:
     @staticmethod
     def get_all_users():
         select_all_users = """
-        SELECT id, username, email FROM users"""
+        SELECT id, username, email, isAdmin FROM users"""
         return UserModel.format_user_list_to_record(db.select_data_from_db(select_all_users))
 
     @staticmethod

--- a/tests/v2/test_users.py
+++ b/tests/v2/test_users.py
@@ -234,7 +234,7 @@ class TestUserEndpoints(BaseTestClass):
         res = self.client.get("api/v2/users")
         result = json.loads(res.data.decode("utf-8"))
         self.assertEqual(result["data"], [
-                         {'email': 'admindetails@gmail.com', 'id': 1, 'username': 'OriginalAdmin'}])
+                         {'email': 'admindetails@gmail.com', 'id': 1, 'username': 'OriginalAdmin', 'isAdmin': True}])
 
     def test_password_without_number(self):
         res = self.client.post("api/v2/auth/signup",


### PR DESCRIPTION
**What does this PR do?**
<!-- A short description of what the pull request does -->
This PR adds the isAdmin payload to the list of users so a user object has the following shape now
```js
{
  "email": String,
  "id": int,
  "username": String,
  "isAdmin": Boolean
}

```


**Description of Task to be completed?**
<!-- Outline the tasks completed by the pr -->
- [x] Refactor test expectation for users list
- [x] Add isAdmin prop on users


**Any background context you want to provide?**
This property will help in making other users admins in the interface.
There will be no need for setting this property to a user who is already an admin, so we will filter the list of users based on this property. So we can have a list of non-admins and a list of admins.

**What are the relevant pivotal tracker stories?**
[#164349046](https://www.pivotaltracker.com/n/projects/2241721/stories/164349046)

**Screenshots (if appropriate)**

![image](https://user-images.githubusercontent.com/12128153/53677142-53dcac80-3cbc-11e9-9329-1c5884b5556a.png)

