### PR TITLE
#164354694 Use Absolute path for sending mail request

### DIFF
--- a/app/api/v2/models/users.py
+++ b/app/api/v2/models/users.py
@@ -7,6 +7,7 @@ import os
 from sendgrid.helpers.mail import Email, Content, Mail
 import jwt
 from app.api import utils
+import sys
 
 
 from . import db
@@ -150,7 +151,13 @@ class UserModel:
             mail = Mail(from_email, subject, to_email, content)
             sg.client.mail.send.post(request_body=mail.get())
         except:
-            abort(utils.response_fn(400, "error", "Something went wrong"))
+            print('Unknown error detected:')
+            # Info about unknown error that caused exception.
+            a = sys.exc_info()
+            print('    ', a)
+            b = [str(p) for p in a]
+            print('    ', b)
+            abort(utils.response_fn(400, "error", "Something went wrongly here"))
 
     @staticmethod
     def update_password(email, newpassword):

--- a/app/api/v2/views/users.py
+++ b/app/api/v2/views/users.py
@@ -130,7 +130,8 @@ def reset_password():
 
     # check if email is valid
     v2utils.isEmailValid(email)
-    link = request.url.replace("reset", "securereset")
+    link = "https://tevpolitico.herokuapp.com/api/v2/auth/securereset"
+
     # send a request to the endpoint that will send the mail
     requests.post(
         link, data=json.dumps({"email": email}),

--- a/tests/v2/test_users.py
+++ b/tests/v2/test_users.py
@@ -328,8 +328,21 @@ class TestUserEndpoints(BaseTestClass):
         self.assertEqual(res.status_code, 400)
 
     def test_secure_endpoint_for_sending_emails(self):
+        self.client.post("api/v2/auth/signup",
+                         data=json.dumps({
+                             "username": "Tevyn",
+                             "firstname": "Tevin",
+                             "lastname": "Gach",
+                             "email": "tevinthuku@gmail.com",
+                             "phone": "0735464438",
+                             "othername": "Thuku",
+                             "password": "Tevinrocks1995",
+                             "retypedpassword": "Tevinrocks1995",
+                             "passportUrl": "http"
+                         }),
+                         content_type="application/json")
         res = self.client.post("api/v2/auth/securereset", data=json.dumps({
-            "email": "admindetails@gmail.com",
+            "email": "tevinthuku@gmail.com",
         }), content_type="application/json")
         self.assertEqual(res.status_code, 200)
 
@@ -362,3 +375,23 @@ class TestUserEndpoints(BaseTestClass):
             "email": "tevothukgmail.com",
         }), content_type="application/json")
         self.assertEqual(res.status_code, 400)
+
+    def test_sending_mail_with_mail(self):
+
+        self.client.post("api/v2/auth/signup",
+                         data=json.dumps({
+                             "username": "Tevyn",
+                             "firstname": "Tevin",
+                             "lastname": "Gach",
+                             "email": "tevinthuku@gmail.com",
+                             "phone": "0735464438",
+                             "othername": "Thuku",
+                             "password": "Tevinrocks1995",
+                             "retypedpassword": "Tevinrocks1995",
+                             "passportUrl": "http"
+                         }),
+                         content_type="application/json")
+        res = self.client.post("api/v2/auth/reset", data=json.dumps({
+            "email": "tevinthuku@gmail.com",
+        }), content_type="application/json")
+        self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
**What does this PR do?**
<!-- A short description of what the pull request does -->
This PR manually sets the API endpoint that will be used to send emails
```
https://tevpolitico.herokuapp.com/api/v2/auth/securereset
```

**Description of Task to be completed?**
<!-- Outline the tasks completed by the pr -->
- [x] Use hosted API endpoint for sending a request
to the secure reset endpoint


**Any background context you want to provide?**
`request.url` does not return the correct absolute path of the API so the URL for the send mail endpoint is being hardcoded for an accurate result of the path to the endpoint

**What are the relevant pivotal tracker stories?**
[#164354694](https://www.pivotaltracker.com/n/projects/2241721/stories/164354694)

